### PR TITLE
Add VB6 keys

### DIFF
--- a/scripts/data/keys.csv
+++ b/scripts/data/keys.csv
@@ -261,6 +261,7 @@
 "Vim Script","Vim_(text_editor)","vim","vim"
 "Vim Snippet","","",""
 "Visual Basic","Visual_Basic","visualbasic","vb"
+"Visual Basic 6.0","Visual_Basic_(classic)","visualbasic","vb6"
 "Visual Basic .NET","Visual_Basic_.NET","visualbasic","vb.net"
 "Vue","Vue.js","vuejs","vue.js"
 "Web Ontology Language","Web_Ontology_Language","semanticweb","owl"


### PR DESCRIPTION
For context, VB6 was added as a seperate language in GitHub last year (https://github.com/github-linguist/linguist/pull/6124).

I saw that the data for GitHub was added to Languish, but not the data for Stack Overflow (SO). I'm assuming that's because the information corresponding to the SO tags was missing. This PR should fix this.